### PR TITLE
Memoize field sizes with datastructures,  improved tests, and a minor fix

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -87,7 +87,8 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">= 4.8",
-  NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ] ],
+  NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ]
+                         , [ "datastructures", ">= 0.0.0"] ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],
 ),

--- a/gap/meataxe64.gi
+++ b/gap/meataxe64.gi
@@ -16,7 +16,7 @@ BindGlobal( "MTX64_BitStringFamily", NewFamily("MTX64_BitStringFamily"));
 BindGlobal( "MTX64_BitStringType",
         NewType(MTX64_BitStringFamily, IsMutable and IsMTX64BitString and IsDataObjectRep) );
 
-BindGlobal("MTX64_FieldEltType", MemoizePosIntFunction(function(q)
+BindGlobal("MTX64_FieldEltType", MemoizeFunction(function(q)
     local fam, type;
     fam := NewFamily(STRINGIFY("MTX64_GF(", q, ")_ElementFamily"));
     fam!.q := q;
@@ -24,7 +24,7 @@ BindGlobal("MTX64_FieldEltType", MemoizePosIntFunction(function(q)
     return NewType(fam, IsMTX64FiniteFieldElement and IsDataObjectRep);
 end, rec(flush := false)));
 
-BIND_GLOBAL("MTX64_MatrixType",MemoizePosIntFunction(function(q)
+BIND_GLOBAL("MTX64_MatrixType",MemoizeFunction(function(q)
     local fam, type;
     fam := NewFamily(STRINGIFY("MTX64_GF(", q, ")_MatrixFamily"));
     fam!.q := q;
@@ -41,7 +41,7 @@ BIND_GLOBAL("FieldOfMTX64FELT", e -> FamilyObj(e)!.field);
 
 InstallMethod( MTX64_FiniteField, "for a size",
                [ IsPosInt ],
-        MemoizePosIntFunction(function(q)
+        MemoizeFunction(function(q)
     if  q >= 2^64 or not IsPrimePowerInt(q) then
         Error("MTX64_FiniteField: field order must be a prime power < 2^64");
     fi;
@@ -85,7 +85,7 @@ InstallMethod( MTX64_FiniteFieldElement, "for a meataxe64 field and an integer",
         [ IsMTX64FiniteField, IsInt ],        
         MTX64_CreateFieldElement);
 
-BindGlobal("MTX64_ConversionTables", MemoizePosIntFunction(function(q)
+BindGlobal("MTX64_ConversionTables", MemoizeFunction(function(q)
     local  f, tab1, tab2, z, y, i, tab3, tab4;
     f := MTX64_FiniteField(q);    
     tab1 := MTX64_MakeFELTfromFFETable(f);
@@ -101,7 +101,7 @@ BindGlobal("MTX64_ConversionTables", MemoizePosIntFunction(function(q)
     return [tab1,tab2];
 end));
 
-BindGlobal("MTX64_ByteTables", MemoizePosIntFunction(function(q)
+BindGlobal("MTX64_ByteTables", MemoizeFunction(function(q)
     local  tab3, tab4, i, f;
     f := MTX64_FiniteField(q);    
     tab3 := MTX64_Make8BitConversion(f);

--- a/scripts/build_gap.sh
+++ b/scripts/build_gap.sh
@@ -37,6 +37,9 @@ make bootstrap-pkg-full WGET="wget -N --no-check-certificate --tries=5 --waitret
 # directly call BuildPackages.sh from .travis.yml. For an example of the
 # former, take a look at the cvec package.
 cd pkg
-for pkg in ${GAP_PKGS_TO_BUILD-io profiling}; do
+
+git clone https://github.com/gap-packages/datastructures
+
+for pkg in ${GAP_PKGS_TO_BUILD-io profiling datastructures}; do
     ../bin/BuildPackages.sh --strict $pkg*
 done

--- a/src/slab.c
+++ b/src/slab.c
@@ -43,6 +43,9 @@ static Obj FuncMTX64_SLEchelizeDestructive(Obj self, Obj a) {
   DSPACE ds;
   DSSet(DataOfFieldObject(field), ncols, &ds);
   rank = SLEch(&ds, mat, rsp, csp, &det, multiply, cleaner, remnant, nrows);
+
+  // TODO: Why should it be ok to not do this?
+  CHANGED_BAG(m); CHANGED_BAG(r); CHANGED_BAG(c);
   // Garbage collection OK again here
   // Resize all the output matrices
   SetShapeAndResize(m, rank, rank);

--- a/src/slab.c
+++ b/src/slab.c
@@ -29,14 +29,17 @@ static Obj FuncMTX64_SLEchelizeDestructive(Obj self, Obj a) {
   Obj field = FieldOfMatrix(a);
   Obj m = NEW_MTX64_Matrix(field, rklimit, rklimit);
   Obj r = NEW_MTX64_Matrix(field, nrows, ncols);   // this may be a bit too high
-  Obj c = NEW_MTX64_Matrix(field, ncols, rklimit); // this is a bit too high, as
+  Obj c = NEW_MTX64_Matrix(field, nrows, rklimit); // this is a bit too high, as
                                                    // both bounds cannot be
                                                    // achieved at once
   // Done with garbage collection here
   uint64_t rank;
-  uint64_t *rsp = DataOfBitStringObject(rs), *csp = DataOfBitStringObject(cs);
-  Dfmt *mat = DataOfMTX64_Matrix(a), *multiply = DataOfMTX64_Matrix(m),
-       *remnant = DataOfMTX64_Matrix(r), *cleaner = DataOfMTX64_Matrix(c);
+  uint64_t *rsp = DataOfBitStringObject(rs);
+  uint64_t *csp = DataOfBitStringObject(cs);
+  Dfmt *mat = DataOfMTX64_Matrix(a);
+  Dfmt *multiply = DataOfMTX64_Matrix(m);
+  Dfmt *remnant = DataOfMTX64_Matrix(r);
+  Dfmt *cleaner = DataOfMTX64_Matrix(c);
   DSPACE ds;
   DSSet(DataOfFieldObject(field), ncols, &ds);
   rank = SLEch(&ds, mat, rsp, csp, &det, multiply, cleaner, remnant, nrows);

--- a/tst/solving.tst
+++ b/tst/solving.tst
@@ -8,7 +8,7 @@ gap> extract_roundtrip := function(n, q)
 >    fi;
 >    return true;
 >    end;;
-gap> for i in [1..3] do extract_roundtrip(Random([2..100]), Random(Primes) ^ Random([1..3])); GASMAN("collect"); od;;
+gap> for i in [1..50] do extract_roundtrip(Random([2..50]), Random(Primes) ^ Random([1..3])); od;;
 
 #
 gap> echelize := function(m, n, q)
@@ -17,7 +17,7 @@ gap> echelize := function(m, n, q)
 >       mat := MTX64_RandomMat(fld, m, n); 
 >       r := MTX64_Echelize(mat);
 >    end;;
-gap> for i in [1..1000] do echelize(Random([2..100]), Random([2..100]), Random(Primes)); od;
+gap> for i in [1..100] do echelize(Random([2..1000]), Random([2..1000]), Random(Primes)); od;
 
 #
 gap> solutionmat := function(n, q)
@@ -25,9 +25,14 @@ gap> solutionmat := function(n, q)
 >       fld := MTX64_FiniteField(q);
 >       mat := MTX64_RandomMat(fld, n, n);
 >       v   := MTX64_RandomMat(fld, 1, n); 
+>       sol := MTX64_SolutionsMat(mat, v)[2];
+>       if (MTX64_Matrix_NumRows(sol) = 1) and
+>          (sol * mat <> -v) then
+>           Error("Not a solution");
+>       fi;
+>       sol    := MTX64_ExtractMatrix(sol);
 >       gapmat := MTX64_ExtractMatrix(mat);
 >       gapv   := MTX64_ExtractMatrix(v)[1];
->       sol    := MTX64_ExtractMatrix(MTX64_SolutionsMat(mat, v)[2]);
 >       gapsol := SolutionMat(gapmat, gapv);
 >       if not ((sol = [] and gapsol = fail) or IsZero(sol[1] + gapsol)) then
 >           Error("Solutions do not match");


### PR DESCRIPTION
This adds

 * memoisation of finite field data using the new `MemoizeFunction` feature of datastructures. This prevents this package from allocating huge empty lists when `MemoizePosIntFunction` tries to memoise a function with a large input number (such as 349^3).
 * using this memoisation, we can run better randomised tests
 * a fix for an allocation error in the C glue code in `src/slab.c` 

