### PR TITLE
Fix MatrixObj integration to work with both GAP 4.10 and 4.11

### DIFF
--- a/gap/meataxe64.gi
+++ b/gap/meataxe64.gi
@@ -503,13 +503,13 @@ end);
     
         
 
-InstallOtherMethod(\[\], "for a meataxe64 matrix and two indices", [IsMTX64Matrix, IsPosInt, IsPosInt], 
+InstallOtherMethod(MatElm, "for a meataxe64 matrix and two indices", [IsMTX64Matrix, IsPosInt, IsPosInt], 
         function(m, i, j)
     return MTX64_GetEntry(m, i-1, j-1);
 end);
 
 
-InstallOtherMethod(\[\]\:\=, "for a meataxe64 matrix and two indices and a FELT", 
+InstallOtherMethod(SetMatElm, "for a meataxe64 matrix and two indices and a FELT", 
         [IsMTX64Matrix and IsMutable, IsPosInt, IsPosInt, IsMTX64FiniteFieldElement], 
         function(m, i, j, x)
     MTX64_SetEntry(m, i-1, j-1, x);


### PR DESCRIPTION
In GAP 4.11, there will be separate kernel operations `ELM_MAT` / `\[\,\]` and
`ASS_MAT` / `\[\,\]\:\=` for MatrixObj access. But `MatElm` and `SetMatElm`
will be synonyms for them. So by installing methods for those two, one can
write code that works both with GAP 4.10 and 4.11.