### PR TITLE
Require GAP >= 4.11

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -87,7 +87,7 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">= 4.10",
+  GAP := ">= 4.11",
                    NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ], 
                            [ "AutoDoc", ">= 0.0.0"],
                           [ "datastructures", ">= 0.0.0"] ],


### PR DESCRIPTION
Several of its features are used by meataxe64