### PR TITLE
Don't depend on AutoDoc; require newer version in makedoc.g

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -89,7 +89,6 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.10",
                    NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ], 
-                           [ "AutoDoc", ">= 0.0.0"],
                           [ "datastructures", ">= 0.0.0"] ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],

--- a/makedoc.g
+++ b/makedoc.g
@@ -3,12 +3,10 @@
 #
 # This file is a script which compiles the package manual.
 #
-if fail = LoadPackage("AutoDoc", "2016.02.16") then
-    Error("AutoDoc version 2016.02.16 or newer is required.");
+if fail = LoadPackage("AutoDoc", "2019.07.03") then
+    Error("AutoDoc version 2019.07.03 or newer is required.");
 fi;
 
 AutoDoc( rec( scaffold := true, autodoc := rec(files := ["doc/Chapters.autodoc"] )) );
 
 QUIT_GAP();
-
-


### PR DESCRIPTION
Since @GroupTitle is in use by meataxe64 but only available in AutoDoc
2019.07.03 and later, require that version in makedoc.g

At the same time, drop the dependency on AutoDoc from PackageInfo.g, as
AutoDoc is not actually needed to load and use meataxe64.

Resolves #37