### PR TITLE
Fix for GAP 4.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ to be compiled).
 Clone the GIT repository and then, from the top directory do
 
 ```
-./autogen.sh
-./configure --with-gap-root=<path to your GAP root directory>
+./configure <path to your GAP root directory>
 make
 ```
 

--- a/gap/matobj.gi
+++ b/gap/matobj.gi
@@ -55,12 +55,12 @@ if IsBound(CompatibleVectorFilter) then
 fi;
 
 
-InstallMethod(NewZeroMatrix,[IsMeataxe64MatrixObj, IsField and IsFinite, IsInt, IsInt],
+InstallMethodOrTagBasedMethod(NewZeroMatrix,[IsMeataxe64MatrixObj, IsField and IsFinite, IsInt, IsInt],
         {filt, R, nor, noc} -> MakeMeataxe64Matrix(MTX64_NewMatrix(MTX64_FiniteField(Size(R)), nor, noc)));
 
 
 
-InstallMethod(NewMatrix,[IsMeataxe64MatrixObj, IsField and IsFinite, IsInt, IsList],
+InstallMethodOrTagBasedMethod(NewMatrix,[IsMeataxe64MatrixObj, IsField and IsFinite, IsInt, IsList],
         function(filt, R, noc, list) 
     local  nor, m, i, l;
     if Length(list) = 0 then

--- a/gap/vecobj.gi
+++ b/gap/vecobj.gi
@@ -242,7 +242,7 @@ end);
 InstallMethod(ConstructingFilter, [IsMeataxe64VectorObj],
         v->IsMeataxe64VectorObj);
 
-InstallMethod(NewVector, [IsMeataxe64VectorObj, IsField and IsFinite, IsList],
+InstallTagBasedMethod(NewVector, IsMeataxe64VectorObj,
         function (t, f, l)
     local  m;
     m := MTX64_NewMatrix(MTX64_FiniteField(Size(f)), 1, Length(l));
@@ -250,7 +250,7 @@ InstallMethod(NewVector, [IsMeataxe64VectorObj, IsField and IsFinite, IsList],
     return MakeMeataxe64Vector(m);
 end);
 
-InstallMethod(NewZeroVector, [IsMeataxe64VectorObj, IsField and IsFinite, IsInt],
+InstallTagBasedMethod(NewZeroVector, IsMeataxe64VectorObj,
         function (t, f, len)
     local  m;
     m := MTX64_NewMatrix(MTX64_FiniteField(Size(f)), 1,len);

--- a/gap/vecobj.gi
+++ b/gap/vecobj.gi
@@ -13,6 +13,16 @@
 #
 
 
+# for compatibility with both GAP 4.13 and older GAP versions
+BindGlobal("InstallMethodOrTagBasedMethod", function(oper, requirements, method)
+  if IsBoundGlobal("InstallTagBasedMethod") then
+    # for GAP 4.13 or newer
+    ValueGlobal("InstallTagBasedMethod")(oper, requirements[1], method);
+  else
+    # for GAP 4.12 or older
+    InstallMethod(oper, requirements, method);
+  fi;
+end);
 
 
 InstallGlobalFunction(UnderlyingMeataxe64Matrix,
@@ -242,7 +252,7 @@ end);
 InstallMethod(ConstructingFilter, [IsMeataxe64VectorObj],
         v->IsMeataxe64VectorObj);
 
-InstallTagBasedMethod(NewVector, IsMeataxe64VectorObj,
+InstallMethodOrTagBasedMethod(NewVector, [IsMeataxe64VectorObj, IsField and IsFinite, IsList],
         function (t, f, l)
     local  m;
     m := MTX64_NewMatrix(MTX64_FiniteField(Size(f)), 1, Length(l));
@@ -250,7 +260,7 @@ InstallTagBasedMethod(NewVector, IsMeataxe64VectorObj,
     return MakeMeataxe64Vector(m);
 end);
 
-InstallTagBasedMethod(NewZeroVector, IsMeataxe64VectorObj,
+InstallMethodOrTagBasedMethod(NewZeroVector, [IsMeataxe64VectorObj, IsField and IsFinite, IsInt],
         function (t, f, len)
     local  m;
     m := MTX64_NewMatrix(MTX64_FiniteField(Size(f)), 1,len);


### PR DESCRIPTION
changes from #46, plus more fixes, plus compatibility with GAP 4.12:

- add `InstallMethodOrTagBasedMethod`
- use it in the methods for `NewMatrix`, `NewZeroMatrix`, `NewVector`, `NewZeroVector`
- update installation instructions
