### PR TITLE
in `ErrorMayQuit` calls, replace `%i` by `%d`

### DIFF
--- a/src/bitstring.c
+++ b/src/bitstring.c
@@ -164,7 +164,7 @@ static Obj FuncMTX64_RowSelectShifted(Obj self, Obj bitstring, Obj m,
   UInt nor = HeaderOfMatrix(m)->nor;
   UInt noc = HeaderOfMatrix(m)->noc;
   if (nor != ishift + DataOfBitStringObject(bitstring)[0])
-    ErrorMayQuit("mismatched matrix length: matrix %i, bitstring + shift %i",
+    ErrorMayQuit("mismatched matrix length: matrix %d, bitstring + shift %d",
                  nor, ishift + DataOfBitStringObject(bitstring)[0]);
   UInt nos = DataOfBitStringObject(bitstring)[1];
   Obj fld = FieldOfMatrix(m);

--- a/src/meataxe64.c
+++ b/src/meataxe64.c
@@ -509,11 +509,11 @@ static Obj FuncMTX64_ELMS_LIST(Obj self, Obj m, Obj rows) {
     for (UInt i = 1;  i <= nor2; i++) {
         Obj ix = ELM_LIST(rows, i);
         if (!IS_INTOBJ(ix))
-            ErrorMayQuit("MTX64_ELMS_LIST: row index %i must be a small integer,"
+            ErrorMayQuit("MTX64_ELMS_LIST: row index %d must be a small integer,"
                          " not a %s", i, (Int)TNAM_OBJ(ix));
         Int ixi = INT_INTOBJ(ix);
         if (0 >= ixi || nor < ixi)
-            ErrorMayQuit("MTX64_ELMS_LIST: row index %i out of range",
+            ErrorMayQuit("MTX64_ELMS_LIST: row index %d out of range",
                          i, 0);
         Dfmt *d1 = DPAdv(&ds, ixi-1, d);
         DCpy(&ds, d1, 1, d2);

--- a/src/meataxe64.h
+++ b/src/meataxe64.h
@@ -185,7 +185,7 @@ static inline void CHECK_SUBFIELD(Obj bigfield, Obj smallfield) {
    UInt qb = DataOfFieldObject(bigfield)->fdef;
    UInt qs = DataOfFieldObject(smallfield)->fdef;
    if (qb % qs != 0) {
-     ErrorMayQuit("Meataxe64: incompatiable field sizes %d %d",qb,qs);
+     ErrorMayQuit("Meataxe64: incompatible field sizes %d %d",qb,qs);
    }
    UInt x = qs;
    while (x < qb) {

--- a/src/meataxe64.h
+++ b/src/meataxe64.h
@@ -172,7 +172,7 @@ static inline void CHECK_MTX64_RowCount(Obj row, Obj m) {
 static inline void CHECK_MTX64_RowRange(Obj startrow, Obj nrows, Obj m) {
   CHECK_NONNEG_SMALLINTS(startrow, nrows);
   if (INT_INTOBJ(startrow) + INT_INTOBJ(nrows) > HeaderOfMatrix(m)->nor)
-    ErrorMayQuit("Meataxe64: row range too large for matrix: %i %i",
+    ErrorMayQuit("Meataxe64: row range too large for matrix: %d %d",
                  INT_INTOBJ(startrow) + INT_INTOBJ(nrows),
                  HeaderOfMatrix(m)->nor);
 }
@@ -185,14 +185,14 @@ static inline void CHECK_SUBFIELD(Obj bigfield, Obj smallfield) {
    UInt qb = DataOfFieldObject(bigfield)->fdef;
    UInt qs = DataOfFieldObject(smallfield)->fdef;
    if (qb % qs != 0) {
-     ErrorMayQuit("Meataxe64: incompatiable field sizes %i %i",qb,qs);
+     ErrorMayQuit("Meataxe64: incompatiable field sizes %d %d",qb,qs);
    }
    UInt x = qs;
    while (x < qb) {
      x *= qs;
    }
    if (x > qb) {
-     ErrorMayQuit("Meataxe64: incompatible field sizes %i %i",qb,qs);
+     ErrorMayQuit("Meataxe64: incompatible field sizes %d %d",qb,qs);
    }
 }
 


### PR DESCRIPTION
the old syntax caused crashes (with GAP 4.12) and `%format error`s (with GAP 4.13)